### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete multi-character sanitization

### DIFF
--- a/backend/storage/schedule.js
+++ b/backend/storage/schedule.js
@@ -64,7 +64,13 @@ function toIsoDate(day, monthName) {
 }
 
 function cleanHtmlToLines(html) {
-  let s = html.replace(/<script[\s\S]*?<\/script>/gi, '').replace(/<style[\s\S]*?<\/style>/gi, '');
+  // Repeat removal of script and style tags to ensure full sanitization
+  let s = html;
+  let prev;
+  do {
+    prev = s;
+    s = s.replace(/<script[\s\S]*?<\/script>/gi, '').replace(/<style[\s\S]*?<\/style>/gi, '');
+  } while (s !== prev);
   s = s.replace(/<\/(tr|table|h\d)>/gi, '\n');
   s = s.replace(/<br\s*\/?>(?=.)/gi, '\n');
   s = s.replace(/<\/(td|th)>/gi, '|');


### PR DESCRIPTION
Potential fix for [https://github.com/Febiunz/petanque-npc/security/code-scanning/8](https://github.com/Febiunz/petanque-npc/security/code-scanning/8)

To fix this problem, the regular expression replacement that removes script tags (`html.replace(/<script[\s\S]*?<\/script>/gi, '')`) should be applied repeatedly until no further changes occur. This ensures all script tags—even those that appear due to collapses from earlier replacements—are fully removed, handling cases where script tags are nested, overlapping, or malformed in a way that could defeat a single-pass replacement.

The optimal fix: In function `cleanHtmlToLines` (lines 66-75), in the first line of the function, instead of a single `.replace` for script tags, use a loop (e.g., `do { ... } while (str !== previousStr)`) to repeatedly remove script tags until none remain. This change can be made directly within the function `cleanHtmlToLines`, and does not require new dependencies or affect other logic in the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
