### PR TITLE
Potential fix for code scanning alert no. 4: Double escaping or unescaping

### DIFF
--- a/backend/storage/fixtures.js
+++ b/backend/storage/fixtures.js
@@ -87,7 +87,7 @@ function cleanHtmlToLines(html) {
   // Strip remaining tags
   s = s.replace(/<[^>]+>/g, ' ');
   // Decode HTML entities minimally
-  s = s.replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&').replace(/&#39;/g, "'").replace(/&quot;/g, '"');
+  s = s.replace(/&nbsp;/g, ' ').replace(/&#39;/g, "'").replace(/&quot;/g, '"').replace(/&amp;/g, '&');
   // Collapse spaces
   s = s.replace(/\s+/g, ' ').replace(/\|\s*\|/g, '|');
   // Split to lines; also keep separators between rows


### PR DESCRIPTION
Potential fix for [https://github.com/Febiunz/petanque-npc/security/code-scanning/4](https://github.com/Febiunz/petanque-npc/security/code-scanning/4)

To fix the problem, we should change the order in which HTML entities are decoded: decode all entities that start with `&` (like `&nbsp;`, `&quot;`, `&#39;`) *before* decoding the ampersand itself (`&amp;`). This way, any ampersands created from decoding `&amp;` will not be subsequently interpreted as the start of an entity and erroneously decoded further. Specifically, in `cleanHtmlToLines`, on line 90, move the `replace(/&amp;/g, '&')` call to the end of the chain so that it is executed after all other entity decodings. No new imports or external dependencies are needed.

Edit only the block in `backend/storage/fixtures.js` containing line 90. No changes elsewhere.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
