### PR TITLE
Potential fix for code scanning alert no. 21: Incomplete multi-character sanitization

### DIFF
--- a/backend/storage/schedule.js
+++ b/backend/storage/schedule.js
@@ -64,21 +64,21 @@ function toIsoDate(day, monthName) {
 }
 
 function cleanHtmlToLines(html) {
-  // Repeat removal of script and style tags to ensure full sanitization
+  // Robustly remove all script and style tags repeatedly until no changes
   let s = html;
   let prev;
   do {
     prev = s;
-    s = s.replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, '').replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, '');
+    s = s.replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, '').replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, '');
   } while (s !== prev);
-  // Also remove any leftover tag fragments repeatedly to prevent incomplete sanitization
+  // Also remove any leftover tag fragments (e.g. incomplete or broken tags) until no more remain
   do {
     prev = s;
     s = s
       .replace(/<script\b/gi, '')
-      .replace(/<\/script>/gi, '')
+      .replace(/<\/script\s*>/gi, '')
       .replace(/<style\b/gi, '')
-      .replace(/<\/style>/gi, '');
+      .replace(/<\/style\s*>/gi, '');
   } while (s !== prev);
   s = s.replace(/<\/(tr|table|h\d)>/gi, '\n');
   s = s.replace(/<br\s*\/?>(?=.)/gi, '\n');


### PR DESCRIPTION
Potential fix for [https://github.com/Febiunz/petanque-npc/security/code-scanning/21](https://github.com/Febiunz/petanque-npc/security/code-scanning/21)

The best way to fix the problem is to either use a dedicated HTML sanitization library (such as `sanitize-html`) or, if this is not an option, ensure that all multi-character patterns used for sanitization are applied repeatedly until no further replacements occur. For the direct fix using your code as shown, you should change the loop that removes `<script>` and `<style>` blocks so that it applies the replacement repeatedly until no more changes occur, as is partially done, but in a more robust and clearer manner. Specifically, apply the multi-character regex for script and style removal repeatedly, then in a subsequent loop, remove leftover fragments (e.g., incomplete opening or closing tags) again in a do-while loop. No library is currently imported for sanitization, so stick to robust repeated replacements. The edits will all be in `backend/storage/schedule.js`, specifically within the `cleanHtmlToLines` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
