### PR TITLE
Potential fix for code scanning alert no. 3: Double escaping or unescaping

### DIFF
--- a/backend/storage/schedule.js
+++ b/backend/storage/schedule.js
@@ -78,7 +78,7 @@ function cleanHtmlToLines(html) {
   s = s.replace(/<br\s*\/?>(?=.)/gi, '\n');
   s = s.replace(/<\/(td|th)>/gi, '|');
   s = s.replace(/<[^>]+>/g, ' ');
-  s = s.replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&').replace(/&#39;/g, "'").replace(/&quot;/g, '"');
+  s = s.replace(/&nbsp;/g, ' ').replace(/&#39;/g, "'").replace(/&quot;/g, '"').replace(/&amp;/g, '&');
   s = s.replace(/\s+/g, ' ').replace(/\|\s*\|/g, '|');
   return s.split(/\n+/).map(l => l.trim()).filter(Boolean);
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Febiunz/petanque-npc/security/code-scanning/3](https://github.com/Febiunz/petanque-npc/security/code-scanning/3)

**General approach:**  
To fix double unescaping, ensure that the ampersand entity (`&amp;`) is decoded only after decoding all other entities. This avoids the case where something like `&amp;quot;` gets replaced with `"` instead of the literal `&quot;`.

**Detailed fix:**  
In the `cleanHtmlToLines` function, the line that does  
```js
s = s.replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&').replace(/&#39;/g, "'").replace(/&quot;/g, '"');
```
should be reordered so the replacement for `&amp;` comes *last*, i.e. after all replacements for other entities.

**Region to change:**  
Only line 81 (`s = s.replace(...)`) needs to be changed, preserving all original replacements but reordering them so `.replace(/&amp;/g, '&')` is last.

No new imports, methods, or definitions are needed—the change is isolated to this line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
